### PR TITLE
Fix error metrics

### DIFF
--- a/internal/collector/eth_block_timestamp.go
+++ b/internal/collector/eth_block_timestamp.go
@@ -34,7 +34,7 @@ func (collector *EthBlockTimestamp) Describe(ch chan<- *prometheus.Desc) {
 func (collector *EthBlockTimestamp) Collect(ch chan<- prometheus.Metric) {
 	var result *blockResult
 
-	if err := collector.rpc.Call(&result, "eth_getBlockByNumber", "latest", 0); err != nil {
+	if err := collector.rpc.Call(&result, "eth_getBlockByNumber", "latest", false); err != nil {
 		ch <- prometheus.NewInvalidMetric(collector.desc, err)
 		return
 	}

--- a/internal/collector/parity_net_peers.go
+++ b/internal/collector/parity_net_peers.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -42,8 +43,9 @@ func (collector *ParityNetPeers) Describe(ch chan<- *prometheus.Desc) {
 func (collector *ParityNetPeers) Collect(ch chan<- prometheus.Metric) {
 	var result *peersResult
 	if err := collector.rpc.Call(&result, "parity_netPeers"); err != nil {
-		ch <- prometheus.NewInvalidMetric(collector.activeDesc, err)
-		ch <- prometheus.NewInvalidMetric(collector.connectedDesc, err)
+		wErr := errors.Wrap(err, "parity metrics are only available in OpenEthereum")
+		ch <- prometheus.NewInvalidMetric(collector.activeDesc, wErr)
+		ch <- prometheus.NewInvalidMetric(collector.connectedDesc, wErr)
 		return
 	}
 


### PR DESCRIPTION
Related Issue

- Fixed `eth_block_timestamp`
- Added error message to `parity` metrics which are only available in OpenEthereum

Sync metrics errors are related to the node which is not synced, nothing changed for that cases.