### PR TITLE
Fix sample exporter config server_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ events_test
 build/
 production/exporter/*.yaml
 !production/exporter/sample.yaml
+*.swp

--- a/production/exporter/sample.yaml
+++ b/production/exporter/sample.yaml
@@ -1,6 +1,6 @@
 general:
   eth_provider_url:
-  server_url: localhost:9368
+  server_url: :9368
   start_block_number: 0
 targets:
   erc20:


### PR DESCRIPTION
Our local setup exposes each container in a local docker-compose network. Grafana agent is `agent`, and the exporter is `exporter`. That said, if we have a `server_url` values `localhost:<some_port>`, the exporter will just expose the `/metrics` endpoint in the local network.

By using just `:<some_port>` the exporter uses the `0.0.0.0` interface, which catches all network traffic, including the agent.